### PR TITLE
fix: replace b-tag with br-tag is intended

### DIFF
--- a/BASH/8_Super_Heroic_Linux_Commands_by_EngineerMan.md
+++ b/BASH/8_Super_Heroic_Linux_Commands_by_EngineerMan.md
@@ -93,7 +93,7 @@ __init__.py
 ```
 david@debian $ cat file | tee -a log | cat > /dev/null
 ```
-<b />
+<br />
 
 
 # Exit terminal... but leave all processes running


### PR DESCRIPTION
The b-tag used causes all following text to be bold, which is quite odd to read.